### PR TITLE
Add parameters to job dispatch method

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ Now that your job listener is running and ready to do some asynchronous work, yo
 ```javascript
 const kue = use('Kue');
 const Job = require('./app/Jobs/Example');
-const data = { test: 'data' };
-const job = kue.dispatch(Job.key, data);
+const data = { test: 'data' }; // Data to be passed to job handle
+const priority = 'normal'; // Priority of job, can be low, normal, medium, high or critical
+const attempts = 1; // Number of times to attempt job if it fails
+const remove = true; // Should jobs be automatically removed on completion
+const job = kue.dispatch(Job.key, data, priority, attempts, remove);
 
 // If you want to wait on the result, you can do this
 const result = yield job.result;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "Nicholas Rempel <nbrempel@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "cat-log": "^1.0.2",
     "co": "^4.6.0",
     "kue": "^0.11.1"
   },

--- a/src/Kue/index.js
+++ b/src/Kue/index.js
@@ -37,16 +37,21 @@ class Kue {
   }
 
   /**
-   * Dispatch a new job.
-   *
-   * @public
-   */
-  dispatch(key, data) {
+  * Dispatch a new job.
+  * @param  {String} key
+  * @param  {Mixed} data       Data to be passed to job
+  * @param  {String} priority  Priority of job
+  * @param  {Number} attempts  How many times to attempt the job
+  * @param  {Boolean} remove   Should completed jobs be removed from kue
+  * @returns {Object}          Kue job instance
+  * @public
+  */
+  dispatch (key, data, priority = 'normal', attempts = 1, remove = true) {
     if (typeof key !== 'string') {
       throw new Error(`Expected job key to be of type string but got <${typeof key}>.`);
     }
-    const job = this.instance.create(key, data).removeOnComplete(true).save(err => {
-       if (err) {
+    const job = this.instance.create(key, data).priority(priority).attempts(attempts).removeOnComplete(remove).save(err => {
+      if (err) {
         this.logger.error('An error has occurred while creating a Kue job.');
         throw err;
       }

--- a/test/kue.spec.js
+++ b/test/kue.spec.js
@@ -83,6 +83,78 @@ describe('Kue', function () {
     expect(job.type).to.equal(Job.key);
     expect(job.data).to.equal(data);
   });
+  
+  it('Should be able to dispatch jobs with default priority', function * () {
+    this.timeout(0);
+    const kue = new Kue(Helpers, Config);
+    const Job = require('./app/Jobs/GoodJob');
+    const data = { test: 'data' };
+    const job = kue.dispatch(Job.key, data, undefined);
+    expect(job.type).to.equal(Job.key);
+    expect(job.data).to.equal(data);
+    console.log(job)
+    expect(job._priority).to.equal(0);
+  });
+  
+  it('Should be able to dispatch jobs with a priority', function * () {
+    this.timeout(0);
+    const kue = new Kue(Helpers, Config);
+    const Job = require('./app/Jobs/GoodJob');
+    const data = { test: 'data' };
+    const priority = 'high'
+    const job = kue.dispatch(Job.key, data, priority);
+    expect(job.type).to.equal(Job.key);
+    expect(job.data).to.equal(data);
+    expect(job._priority).to.equal(-10);
+  });
+  
+  it('Should be able to dispatch jobs with default max attempts limit', function * () {
+    this.timeout(0);
+    const kue = new Kue(Helpers, Config);
+    const Job = require('./app/Jobs/GoodJob');
+    const data = { test: 'data' };
+    const job = kue.dispatch(Job.key, data, undefined, undefined);
+    expect(job.type).to.equal(Job.key);
+    expect(job.data).to.equal(data);
+    expect(job._max_attempts).to.equal(1);
+  });
+  
+  it('Should be able to dispatch jobs with a max attempts limit', function * () {
+    this.timeout(0);
+    const kue = new Kue(Helpers, Config);
+    const Job = require('./app/Jobs/GoodJob');
+    const data = { test: 'data' };
+    const attempts = 5
+    const job = kue.dispatch(Job.key, data, undefined, attempts);
+    expect(job.type).to.equal(Job.key);
+    expect(job.data).to.equal(data);
+    expect(job._max_attempts).to.equal(attempts);
+  });
+  
+  it('Should be able to dispatch jobs with default removeOnComplete', function * () {
+    this.timeout(0);
+    const kue = new Kue(Helpers, Config);
+    const Job = require('./app/Jobs/GoodJob');
+    const data = { test: 'data' };
+    const job = kue.dispatch(Job.key, data, undefined);
+    expect(job.type).to.equal(Job.key);
+    expect(job.data).to.equal(data);
+    console.log(job)
+    expect(job._removeOnComplete).to.equal(true);
+  });
+  
+  it('Should be able to dispatch jobs with a configured removeOnComplete', function * () {
+    this.timeout(0);
+    const kue = new Kue(Helpers, Config);
+    const Job = require('./app/Jobs/GoodJob');
+    const data = { test: 'data' };
+    const remove = false
+    const job = kue.dispatch(Job.key, data, undefined, undefined, remove);
+    expect(job.type).to.equal(Job.key);
+    expect(job.data).to.equal(data);
+    console.log(job)
+    expect(job._removeOnComplete).to.equal(false);
+  });
 
   it('Should be able to wait on result of job', function * () {
     this.timeout(0);


### PR DESCRIPTION
Add priority, attempts and removeOnComplete params with defaults, passing them straight to the the kue create call.

Closes #5 but does so in a more useful way than #6 IMO. A developer might want to set different parameters for different job dispatches rather than have the same for all jobs in the application.