### PR TITLE
Move options to be an object, add jobFn option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ const data = { test: 'data' } // Data to be passed to job handle
 const priority = 'normal' // Priority of job, can be low, normal, medium, high or critical
 const attempts = 1 // Number of times to attempt job if it fails
 const remove = true // Should jobs be automatically removed on completion
-const job = kue.dispatch(Job.key, data, priority, attempts, remove)
+const jobFn = job => { // Function to be run on the job before it is saved
+  job.backoff()
+}
+const job = kue.dispatch(Job.key, data, { priority, attempts, remove, jobFn })
 
 // If you want to wait on the result, you can do this
 const result = await job.result


### PR DESCRIPTION
The current implementation doesn't allow you to do anything with the job before it is saved.

This means that any custom work you'd like to do on the job is limited... for example you cannot specify a retry backoff.

Would need to be a major version release, alternatively could add an extra argument for jobFn and have a minor version but an options object is significantly easier to read